### PR TITLE
doc: bump openshift-maven-plugin to v1.8.0

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -93,7 +93,7 @@ In `pom.xml` add [jkube](https://github.com/eclipse/jkube/tree/master/openshift-
 <plugin>
 	<groupId>org.eclipse.jkube</groupId>
 	<artifactId>openshift-maven-plugin</artifactId>
-	<version>1.7.0</version>
+	<version>1.8.0</version>
 </plugin>
 ```
 


### PR DESCRIPTION
Use latest available Eclipse JKube release.

It was really great to see Eclipse JKube mentioned in this repository, I hope that you are happy with its features.