### PR TITLE
Skip tests in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM maven AS build
 COPY src /home/app/src
 COPY pom.xml /home/app
-RUN mvn -f /home/app/pom.xml clean package
+RUN mvn -DskipTests -f /home/app/pom.xml clean package
 
 #
 # Package stage


### PR DESCRIPTION
Added -DskipTests to build so Redis didn't need to be running in order to build the image.

Signed-off-by: André Srinivasan <andre@redis.com>